### PR TITLE
Feat: 하단툴바 추가, 분기처리 및 타입가드 설정

### DIFF
--- a/src/components/ToolbarInitialClickedCase.tsx
+++ b/src/components/ToolbarInitialClickedCase.tsx
@@ -1,0 +1,86 @@
+import Image from "next/image";
+
+interface IToolbarInitialClickedCaseProp {
+  modeName: string; //initial | clicked
+  onCreateText?: () => void; //[initial Mode]
+  onCreateImage?: () => void;
+  onCreateSection?: () => void;
+  onFoldingAll?: () => void;
+  onPreview?: () => void;
+  onRandomize?: () => void; //[clicked Mode]
+  onFolding?: () => void;
+  onSettingQuater?: () => void;
+}
+
+const ToolbarInitialClickedCase = ({
+  modeName,
+  onCreateText,
+  onCreateImage,
+  onCreateSection,
+  onFoldingAll,
+  onPreview,
+  onRandomize,
+  onFolding,
+  onSettingQuater,
+}: IToolbarInitialClickedCaseProp): JSX.Element => {
+  const imageNameInitial = ["fold", "preview", "section", "image", "text"];
+  const toolPartInitial = [
+    onFoldingAll,
+    onPreview,
+    onCreateSection,
+    onCreateImage,
+    onCreateText,
+  ];
+  const imageNameClicked = ["random", "fold", "quater"];
+  const toolPartClicked = [onRandomize, onFolding, onSettingQuater];
+
+  return (
+    <div className="fixed bottom-[0px] flex h-[49px] w-full min-w-[360px] items-center justify-end gap-n-md bg-n-light-black p-n-md">
+      {modeName === "initial" &&
+      onCreateText &&
+      onCreateImage &&
+      onCreateSection &&
+      onFoldingAll &&
+      onPreview ? (
+        <div className="flex items-center justify-end gap-n-md">
+          {toolPartInitial.map((tool, index) => (
+            <button key={index} onClick={tool}>
+              <Image
+                priority
+                src={`/images/${imageNameInitial[index]}.svg`}
+                alt=""
+                width={24}
+                height={24}
+              ></Image>
+            </button>
+          ))}
+        </div>
+      ) : (
+        <div>
+          {
+            <div className="flex items-center justify-end gap-n-md">
+              {modeName === "clicked" &&
+              onRandomize &&
+              onFolding &&
+              onSettingQuater
+                ? toolPartClicked.map((tool, index) => (
+                    <button key={index} onClick={tool}>
+                      <Image
+                        priority
+                        src={`/images/${imageNameClicked[index]}.svg`}
+                        alt=""
+                        width={24}
+                        height={24}
+                      ></Image>
+                    </button>
+                  ))
+                : ""}
+            </div>
+          }
+        </div>
+      )}
+    </div>
+  );
+};
+
+export default ToolbarInitialClickedCase;

--- a/src/components/ToolbarTypingCase.tsx
+++ b/src/components/ToolbarTypingCase.tsx
@@ -1,0 +1,79 @@
+import Image from "next/image";
+
+interface IToolbarTypeCaseProp {
+  modeName: string; //type
+  onFocusUp: () => void;
+  onFocusDown: () => void;
+  onDuplicate: () => void;
+  onConfirm: () => void;
+  onEnter: () => void;
+}
+
+const ToolbarTypeCase = ({
+  modeName,
+  onFocusUp,
+  onFocusDown,
+  onDuplicate,
+  onConfirm,
+  onEnter,
+}: IToolbarTypeCaseProp): JSX.Element => {
+  const imageName = ["duplicate_white", "down", "up", "enter", "confirm"];
+  const toolPartLeft = [onDuplicate, onFocusDown, onFocusUp];
+  const toolPartRight = [onEnter, onConfirm];
+  return (
+    <div>
+      {modeName === "type" ? (
+        <div className="fixed bottom-[0px] flex h-[49px] w-full min-w-[360px] justify-between bg-n-light-black px-n-md py-n-sm">
+          <div className="flex items-center gap-n-sm">
+            {toolPartLeft.map((tool, index) => (
+              <button
+                key={index}
+                onClick={tool}
+                className="flex h-[34px] w-[34px] items-center justify-center rounded-[5px] bg-[#7f7f7f]"
+              >
+                <Image
+                  priority
+                  src={`/images/${imageName[index]}.svg`}
+                  alt=""
+                  width={24}
+                  height={24}
+                />
+              </button>
+            ))}
+          </div>
+          <div className="flex items-center gap-n-sm">
+            <div className="mr-n-sm h-[30px] w-[1px] bg-n-dark-gray"></div>
+            <button
+              onClick={toolPartRight[0]}
+              className="flex h-[34px] w-[34px] items-center justify-center rounded-[5px] bg-n-blue"
+            >
+              <Image
+                priority
+                src={`/images/${imageName[3]}.svg`}
+                alt=""
+                width={24}
+                height={24}
+              />
+            </button>
+            <button
+              onClick={toolPartRight[1]}
+              className="flex h-[34px] w-[51px]  items-center justify-center rounded-[5px] bg-n-purple"
+            >
+              <Image
+                priority
+                src={`/images/${imageName[4]}.svg`}
+                alt=""
+                width={24}
+                height={24}
+              />
+            </button>
+          </div>
+        </div>
+      ) : (
+        ""
+      )}
+    </div>
+  );
+};
+
+export default ToolbarTypeCase;


### PR DESCRIPTION
## 개요

- ToolbarInitialClickedCase/ToolbarTypingCase 추가

## PR타입

- [x] Feature : 기능 추가
- [ ] Fix: 버그 수정
- [ ] Style: 폴더 구조 및 파일명 변경, 단순 변수 수정 등
- [ ] Docs: 문서 수정F
- [ ] Chore: 빌드 업무 및 패키지 업무 등

## 변경사항 및 기능설명
(1) ToolbarInitialClickedCase
- Editor 페이지에서 사용되는 상단 검은색 바입니다
- Editor 초기 진입시 / form 클릭시 사용됩니다
- initial, clicked 모드를 지원합니다 (type 모드 제외)
- 각 모드에 맞는 props를 전달해주셔야 정상적으로 실행됩니다

(2) ToolbarTypingCase 
- Editor 페이지에서 사용되는 상단 검은색 바입니다
- form 클릭 후 편집모드에서 사용됩니다
- 각 모드에 맞는 props를 전달해주셔야 정상적으로 실행됩니다
- 가상키보드 표출에 따른 이슈는 반영하지 않았습니다

## 관련 이슈 넘버

#10 