### PR TITLE
Feat: 하단 이전/다음버튼 추가(sorted)

### DIFF
--- a/src/components/NextPreviousButton.tsx
+++ b/src/components/NextPreviousButton.tsx
@@ -1,0 +1,53 @@
+interface INextPreviousButtonProps {
+  modeName: string; //single | double
+  buttonText: string[];
+  onClick?: () => void; //[single Mode]
+  onLeftClick?: () => void; //[double Mode]
+  onRightClick?: () => void;
+}
+
+const NextPreviousButton = ({
+  modeName,
+  buttonText,
+  onClick,
+  onLeftClick,
+  onRightClick,
+}: INextPreviousButtonProps): JSX.Element => {
+  return (
+    <div>
+      {modeName === "single" && onClick ? (
+        <div className="fixed bottom-0 flex h-[56px] w-full min-w-[360px] text-center leading-[56px] text-n-white">
+          <button
+            className="h-full w-full min-w-[181px] bg-n-blue text-center text-n-xl leading-[56px] text-[white]"
+            onClick={onClick}
+          >
+            {buttonText[0]}
+          </button>
+        </div>
+      ) : (
+        <div>
+          {modeName === "double" && onLeftClick && onRightClick ? (
+            <div className="fixed bottom-0 flex h-[56px] w-full min-w-[360px] text-center leading-[56px] text-n-white">
+              <button
+                className="h-full w-[50%] min-w-[181px] border border-solid border-n-gray bg-n-white text-center text-n-xl leading-[56px] text-n-dark-gray"
+                onClick={onLeftClick}
+              >
+                {buttonText[0]}
+              </button>
+              <button
+                className="h-full w-[50%] min-w-[181px] bg-n-blue text-center text-n-xl leading-[56px] text-[white]"
+                onClick={onRightClick}
+              >
+                {buttonText[1]}
+              </button>
+            </div>
+          ) : (
+            ""
+          )}
+        </div>
+      )}
+    </div>
+  );
+};
+
+export default NextPreviousButton;


### PR DESCRIPTION
## 개요

- NextPreviousButton 추가

## PR타입

- [x] Feature : 기능 추가
- [ ] Fix: 버그 수정
- [ ] Style: 폴더 구조 및 파일명 변경, 단순 변수 수정 등
- [ ] Docs: 문서 수정
- [ ] Chore: 빌드 업무 및 패키지 업무 등

## 변경사항 및 기능설명

- 하단의 이전/다음 버튼입니다
- 버튼 1개(single)/버튼 2개(double) 모드로 분기처리되어있습니다
- 버튼 모드, 버튼 텍스트, func 커스텀이 가능합니다
- 각 모드에 맞는 props를 전달해주셔야 정상적으로 실행됩니다

## 관련 이슈 넘버

#11